### PR TITLE
Fixed Final Exam bug; Updated with the Pizza Party Patch

### DIFF
--- a/resources/schedule.md
+++ b/resources/schedule.md
@@ -56,4 +56,4 @@
 | 16     | 12.11        |                 | Structural Induction on Trees             |			    |			      | 
 |        | 12.13        |                 | Huffman Encoding                          |			    |	[hmwk13 (written)](https://piazza.com/class_profile/get_resource/j6pcg3q79jl3c7/jaxk5o9uqw86k7)		      | 
 |        | 12.15        |                 | **READING DAY - FINAL EXAM REVIEW**	      |			    |	[All Moodle (II)](https://moodle.cs.colorado.edu/mod/quiz/view.php?id=18062)		      | 
-| 17     | 12.XX        |                 | **FINAL EXAM**                            |			    |			      | 
+| 17     | 12.XX        |                 | **PIZZA PARTY**                           |			    |			      | 


### PR DESCRIPTION
Found a bug in the syllabus; seems there's a `final exam` scheduled for the end of the semester?

I try to run the syllabus on my hard drive but kept getting a buffer overflow, like so:

```
1papaya@1love:~/classes/csci2824$ ./syllabus.md
ERROR: Buffer Overflow on line 59: Not enough RAM for this amount of sick maths knowledge
```

With the Pizza Party Patch the syllabus runs super smoothe:

```
1papaya@1love:~/classes/csci2824$ ./syllabus.md

 ____                   
/    \			
  u  u|      _______    
    \ |  .-''#%&#&%#``-.   
   = /  ((%&#&#&%&%#&&%&))  
    |    `-._#%&##&%_.-'   
 /\/\`--.   `-."".-'
 |  |    \   /`./          
 |\/|  \  `-'  /
 || |   \     /            

NOM NOM NOM!!!!
Exit with status "Hallejuliah!!"
```

Great syllabus tho! Just a small bug.